### PR TITLE
Bluetooth | Add pairing-specific logic

### DIFF
--- a/lib/pages/setup/bluetooth.dart
+++ b/lib/pages/setup/bluetooth.dart
@@ -119,7 +119,7 @@ class _BluetoothPageState extends State<BluetoothPage> {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   const Text(
-                      "To ensure proper functionality, please pair with the bin. You should have received a notification asking to pair with the bin.\nYou may need to pair multiple times."),
+                      "To ensure proper functionality, please pair with the bin.\nYou may be prompted to pair more than once."),
                   const SizedBox(height: 10),
                   const SizedBox(
                     height: 50,

--- a/lib/pages/setup/bluetooth.dart
+++ b/lib/pages/setup/bluetooth.dart
@@ -251,16 +251,33 @@ class _BluetoothListState extends State<BluetoothList> {
 
     return Scaffold(
       body: CustomBackground(
-        child: ScanList(
-          itemCount: devices.length,
-          listBuilder: buildDeviceItem,
-          onResume: () {
-            setState(() {
-              startScanning();
-            });
-          },
-          title: "Find your bin!",
-          inProgress: isScanning,
+        child: Column(
+          children: [
+            ScanList(
+              itemCount: devices.length,
+              listBuilder: buildDeviceItem,
+              onResume: () {
+                setState(() {
+                  startScanning();
+                });
+              },
+              title: "Find your bin!",
+              inProgress: isScanning,
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                stopScanning();
+                GoRouter.of(context).goNamed('main');
+              },
+              child: Text(
+                "Skip Setup",
+                style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                      color: Theme.of(context).colorScheme.onPrimary,
+                    ),
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/pages/setup/bluetooth.dart
+++ b/lib/pages/setup/bluetooth.dart
@@ -87,7 +87,7 @@ class _BluetoothPageState extends State<BluetoothPage> {
             );
             return AlertDialog(
               title: Text(
-                "Connection complete! Moving on...",
+                "Bluetooth connection complete! Moving on...",
                 textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.headlineMedium,
               ),

--- a/lib/pages/setup/wifi_configuration.dart
+++ b/lib/pages/setup/wifi_configuration.dart
@@ -187,8 +187,12 @@ class _WifiConfigurationDialogState extends State<WifiConfigurationDialog> {
           serviceId: mainServiceId,
           characteristicId: wifiCredentialCharacteristicId);
       debug("Status Data: $statusData");
-      final Map<dynamic, dynamic> statusJson =
-          jsonDecode(utf8.decode(statusData));
+      late Map<dynamic, dynamic> statusJson;
+      try {
+        statusJson = jsonDecode(utf8.decode(statusData));
+      } catch (e) {
+        continue;
+      }
       double timestamp = statusJson["timestamp"]; // in seconds
       String message = statusJson["message"];
       bool success = statusJson["success"];

--- a/lib/pages/setup/wifi_configuration.dart
+++ b/lib/pages/setup/wifi_configuration.dart
@@ -195,6 +195,7 @@ class _WifiConfigurationDialogState extends State<WifiConfigurationDialog> {
       }
       double timestamp = statusJson["timestamp"]; // in seconds
       String message = statusJson["message"];
+      String? log = statusJson["log"];
       bool success = statusJson["success"];
       debug("Status: $statusJson");
       // check if timestamp is within ~5 seconds of now
@@ -209,7 +210,7 @@ class _WifiConfigurationDialogState extends State<WifiConfigurationDialog> {
           if (!mounted) return;
           setState(() {
             status = WifiConfigurationStatus.error;
-            error = WifiConfigurationException(message);
+            error = WifiConfigurationException('$message, $log');
           });
           return;
         }

--- a/lib/pages/setup/wifi_scan.dart
+++ b/lib/pages/setup/wifi_scan.dart
@@ -59,6 +59,7 @@ class _WifiScanPageState extends State<WifiScanPage> {
           onNotification: (data) {
             try {
               final List<dynamic> content = jsonDecode(utf8.decode(data));
+              debug("WiFi scan results: $content");
               setState(() {
                 wifiResults = content
                     .map((e) => WifiScanResult(e[0], e[1], e[2]))

--- a/lib/util/bluetooth.dart
+++ b/lib/util/bluetooth.dart
@@ -245,7 +245,10 @@ class BleDevice {
     _emit(BleDeviceClientEvents.connected, null);
   }
 
-  /// Pairs the device. (non-Android only)
+  /// Pairs the device and finds its services.
+  ///
+  /// On Android, it will still try to find services if bonded.
+  /// However, if not bonded, the user has to manually pair the device.
   Future<void> _pair() async {
     // On iOS, the device should be paired after connecting
     // on Android, we'll have to request pairing first

--- a/lib/util/bluetooth.dart
+++ b/lib/util/bluetooth.dart
@@ -259,6 +259,10 @@ class BleDevice {
       debug(
           "BleDevice[_pair]: Platform is Android, skipping pairing - must be done manually");
     }
+    // However, if previously bonded, fetch services
+    if (isBonded) {
+      await _device.discoverServices();
+    }
   }
 
   /// Waits for the device to be paired. (Android only)
@@ -306,7 +310,8 @@ class BleDevice {
       debug("BleDevice[waitForPair]: $e");
       timer?.cancel();
       removeListener(BleDeviceClientEvents.bonded, callback);
-      rethrow;
+      throw BleOperationFailureException(
+          "Failed to wait for device to be bonded: $e");
     }
     removeListener(BleDeviceClientEvents.bonded, callback);
     await _updateServices();

--- a/lib/util/bluetooth.dart
+++ b/lib/util/bluetooth.dart
@@ -192,6 +192,9 @@ class BleDevice {
       try {
         await _device.connect();
         debug("BleDevice[connect]: Connection initialized successfully");
+        if (Platform.isAndroid) {
+          await _device.clearGattCache();
+        }
         await _device.discoverServices();
         debug("BleDevice[connect]: Discovered services");
         break;

--- a/lib/util/bluetooth_bin_data.dart
+++ b/lib/util/bluetooth_bin_data.dart
@@ -36,6 +36,7 @@ final wifiStatusCharacteristicId =
 /// {
 ///   "message": "Wi-Fi configuration successful",
 ///   "success": true,
+///   "log": "...", // log of the operation (useful for errors)
 ///   "timestamp": 123456789.5 // Unix timestamp (seconds)
 /// }
 /// ```

--- a/lib/util/bluetooth_exception.dart
+++ b/lib/util/bluetooth_exception.dart
@@ -1,3 +1,4 @@
+/// Thrown when the user denies a required permission
 class BlePermissionException implements Exception {
   final String message;
 
@@ -9,6 +10,7 @@ class BlePermissionException implements Exception {
   }
 }
 
+/// Thrown when the device does not support Bluetooth
 class BleBluetoothNotSupportedException implements Exception {
   final String message;
 
@@ -20,6 +22,7 @@ class BleBluetoothNotSupportedException implements Exception {
   }
 }
 
+/// Thrown when Bluetooth is disabled
 class BleBluetoothDisabledException implements Exception {
   final String message;
 
@@ -31,6 +34,7 @@ class BleBluetoothDisabledException implements Exception {
   }
 }
 
+/// Thrown when the app is unable to connect to the device
 class BleConnectionException implements Exception {
   final String message;
 
@@ -42,6 +46,7 @@ class BleConnectionException implements Exception {
   }
 }
 
+/// Thrown when an operation is performed on something that does not support it
 class BleInvalidOperationException implements Exception {
   final String message;
 
@@ -53,6 +58,7 @@ class BleInvalidOperationException implements Exception {
   }
 }
 
+/// Thrown when an operation fails (timeout, other error)
 class BleOperationFailureException implements Exception {
   final String message;
 

--- a/lib/util/providers.dart
+++ b/lib/util/providers.dart
@@ -27,6 +27,8 @@ class DeviceNotifier with ChangeNotifier {
         BleDeviceClientEvents.connected, _onConnectionChange);
     device?.removeListener(
         BleDeviceClientEvents.disconnected, _onConnectionChange);
+    device?.removeListener(
+        BleDeviceClientEvents.bondChange, _onConnectionChange);
     device?.disconnect();
     device = null;
     notifyListeners();
@@ -41,6 +43,7 @@ class DeviceNotifier with ChangeNotifier {
   void listenForConnectionEvents() {
     device?.onConnected(_onConnectionChange);
     device?.onDisconnected(_onConnectionChange);
+    device?.onBondChange(_onConnectionChange);
   }
 
   /// Connects to the device and notifies when the connection is complete.

--- a/lib/util/providers.dart
+++ b/lib/util/providers.dart
@@ -1,3 +1,4 @@
+import 'package:binsight_ai/util/print.dart';
 import 'package:flutter/material.dart';
 import 'package:binsight_ai/util/bluetooth.dart';
 
@@ -27,8 +28,6 @@ class DeviceNotifier with ChangeNotifier {
         BleDeviceClientEvents.connected, _onConnectionChange);
     device?.removeListener(
         BleDeviceClientEvents.disconnected, _onConnectionChange);
-    device?.removeListener(
-        BleDeviceClientEvents.bondChange, _onConnectionChange);
     device?.disconnect();
     device = null;
     notifyListeners();
@@ -43,7 +42,20 @@ class DeviceNotifier with ChangeNotifier {
   void listenForConnectionEvents() {
     device?.onConnected(_onConnectionChange);
     device?.onDisconnected(_onConnectionChange);
-    device?.onBondChange(_onConnectionChange);
+  }
+
+  /// Pairs with the device and notifies when the pairing is complete.
+  ///
+  /// This method can be awaited to wait for the pairing to complete.
+  Future<void> pair() async {
+    try {
+      error = null;
+      await device?.waitForPair();
+    } on Exception catch (e) {
+      debug("DeviceNotifier[pair]: Failed: $e");
+      error = e;
+    }
+    notifyListeners();
   }
 
   /// Connects to the device and notifies when the connection is complete.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* On Android, doesn't continue to WiFi scan until user has paired device completely
* Adds a small time after connection is made before continuing to next screen
* Adds a skip button to the initial bluetooth scan page

## Screenhots

![image](https://github.com/Soundbendor/smart-bin-app/assets/32113157/c432a26d-abd0-4407-bfca-109c84935211)
![image](https://github.com/Soundbendor/smart-bin-app/assets/32113157/449e1efe-f4fd-4308-aa0b-98cba2a33965)
