### PR TITLE
Fix Startup Icon Size

### DIFF
--- a/android/app/src/main/res/drawable/splash_inset.xml
+++ b/android/app/src/main/res/drawable/splash_inset.xml
@@ -1,0 +1,6 @@
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/splash"
+    android:insetLeft="25dp"
+    android:insetRight="25dp"
+    android:insetTop="25dp"
+    android:insetBottom="25dp"/>

--- a/android/app/src/main/res/values-v31/styles.xml
+++ b/android/app/src/main/res/values-v31/styles.xml
@@ -8,7 +8,7 @@
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
         <item name="android:windowSplashScreenBackground">#ffffff</item>
         <item name="android:windowSplashScreenBrandingImage">@drawable/android12branding</item>
-        <item name="android:windowSplashScreenAnimatedIcon">@drawable/android12splash</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@drawable/splash_inset</item>
     </style>
     <!-- Theme applied to the Android Window as soon as the process has started.
          This theme determines the color of the Android Window while your


### PR DESCRIPTION
## Description
* Created splash_inset.xml file to properly size startup splash icon

## Related Issues
* References #101
* Resolves #159 

## Screenhots
### Before:
![image](https://github.com/Soundbendor/smart-bin-app/assets/91357046/9a2b8cc5-1c21-481f-976a-cd024f0e5d53)
### After:
![image](https://github.com/Soundbendor/smart-bin-app/assets/91357046/6ed5f800-2be1-4e74-b93e-0c6408f16f07)