### PR TITLE
Fix annotation scroll issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+node_modules/

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -163,7 +163,7 @@ void main() async {
       // Skip initial set up if user has already set up a device
       child: BinsightAiApp(
           skipSetUp:
-              true || sharedPreferences.getString(SharedPreferencesKeys.deviceID) !=
+              sharedPreferences.getString(SharedPreferencesKeys.deviceID) !=
                   null),
     ),
   );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -163,7 +163,7 @@ void main() async {
       // Skip initial set up if user has already set up a device
       child: BinsightAiApp(
           skipSetUp:
-              sharedPreferences.getString(SharedPreferencesKeys.deviceID) !=
+              true || sharedPreferences.getString(SharedPreferencesKeys.deviceID) !=
                   null),
     ),
   );

--- a/lib/pages/detection/annotation.dart
+++ b/lib/pages/detection/annotation.dart
@@ -265,11 +265,15 @@ class _AnnotationPageState extends State<AnnotationPage> {
                         icon: const Icon(Icons.redo)),
                   ],
                 ),
-                Text(
-                  annotationNotifier.label == null
-                      ? 'No label selected yet'
-                      : 'Selected Label: ${annotationNotifier.label}',
-                  style: textTheme.labelLarge,
+                Flexible(
+                  child: Text(
+                    annotationNotifier.label == null
+                        ? 'No label selected yet'
+                        : 'Selected Label: ${annotationNotifier.label}',
+                    style: textTheme.labelLarge,
+                    overflow: TextOverflow.fade,
+                    softWrap: false,
+                  ),
                 ),
               ],
             ),

--- a/lib/pages/detection/annotation.dart
+++ b/lib/pages/detection/annotation.dart
@@ -266,13 +266,16 @@ class _AnnotationPageState extends State<AnnotationPage> {
                   ],
                 ),
                 Flexible(
-                  child: Text(
-                    annotationNotifier.label == null
-                        ? 'No label selected yet'
-                        : 'Selected Label: ${annotationNotifier.label}',
-                    style: textTheme.labelLarge,
-                    overflow: TextOverflow.fade,
-                    softWrap: false,
+                  child: Container(
+                    margin: const EdgeInsets.symmetric(horizontal: 8),
+                    child: Text(
+                      annotationNotifier.label == null
+                          ? 'No label selected yet'
+                          : 'Selected Label: ${annotationNotifier.label}',
+                      style: textTheme.labelLarge,
+                      overflow: TextOverflow.fade,
+                      softWrap: false,
+                    ),
                   ),
                 ),
               ],

--- a/lib/pages/detection/annotation.dart
+++ b/lib/pages/detection/annotation.dart
@@ -502,45 +502,52 @@ class _MyAlertDialogState extends State<MyAlertDialog> {
               ),
               Padding(
                 padding: const EdgeInsets.all(8.0),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                child: Wrap(
+                  spacing: 2,
                   children: [
-                    TextButton(
-                      onPressed: () {
-                        // Only pop out of the dialog when pressing submit if you've selected a label
-                        if (widget.controller.getPickedItems().isNotEmpty) {
-                          context.read<AnnotationNotifier>().setLabel(
-                              widget.controller.getPickedItems()[0]["Label"]
-                                  ["name"]);
-                          Navigator.of(context).pop();
-                        }
-                      },
-                      child: const Text("Submit"),
+                    Container(
+                      margin: const EdgeInsets.symmetric(horizontal: 4),
+                      child: TextButton(
+                        onPressed: () {
+                          // Only pop out of the dialog when pressing submit if you've selected a label
+                          if (widget.controller.getPickedItems().isNotEmpty) {
+                            context.read<AnnotationNotifier>().setLabel(
+                                widget.controller.getPickedItems()[0]["Label"]
+                                    ["name"]);
+                            Navigator.of(context).pop();
+                          }
+                        },
+                        child: const Text("Submit"),
+                      ),
                     ),
-                    selectedLabel != null
-                        ? TextButton(
-                            style: ButtonStyle(
-                                backgroundColor:
-                                    MaterialStateProperty.all<Color>(
-                                        Colors.red)),
-                            onPressed: () => setState(
-                              () {
-                                selectedLabel = null;
-                                widget.controller.clearAllPickedItems();
-                              },
-                            ),
-                            child: const Text(
-                              "Clear",
-                            ),
-                          )
-                        : const Text(""),
-                    TextButton(
-                      style: ButtonStyle(
-                          backgroundColor:
-                              MaterialStateProperty.all<Color>(Colors.grey)),
-                      onPressed: () => Navigator.of(context).pop(),
-                      child: const Text(
-                        "Cancel",
+                    if (selectedLabel != null)
+                      Container(
+                        margin: const EdgeInsets.symmetric(horizontal: 4),
+                        child: TextButton(
+                          style: ButtonStyle(
+                              backgroundColor:
+                                  MaterialStateProperty.all<Color>(Colors.red)),
+                          onPressed: () => setState(
+                            () {
+                              selectedLabel = null;
+                              widget.controller.clearAllPickedItems();
+                            },
+                          ),
+                          child: const Text(
+                            "Clear",
+                          ),
+                        ),
+                      ),
+                    Container(
+                      margin: const EdgeInsets.symmetric(horizontal: 4),
+                      child: TextButton(
+                        style: ButtonStyle(
+                            backgroundColor:
+                                MaterialStateProperty.all<Color>(Colors.grey)),
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: const Text(
+                          "Cancel",
+                        ),
                       ),
                     ),
                   ],

--- a/lib/pages/detection/annotation.dart
+++ b/lib/pages/detection/annotation.dart
@@ -1,9 +1,7 @@
 // Flutter imports:
 import 'dart:convert';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 
 // Package imports:
 import 'package:go_router/go_router.dart';
@@ -173,6 +171,7 @@ class _AnnotationPageState extends State<AnnotationPage> {
                       heading(textTheme, context),
                       drawingArea(textTheme),
                       drawingControlArea(textTheme, notifier),
+                      const SizedBox(height: 16),
                       bottomControlArea(
                           context, annotationNotifier, notifier, textTheme),
                     ],
@@ -191,60 +190,38 @@ class _AnnotationPageState extends State<AnnotationPage> {
       AnnotationNotifier annotationNotifier,
       DetectionNotifier notifier,
       TextTheme textTheme) {
-    return Expanded(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          const SizedBox(),
-          Container(
-            decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.surface,
-            ),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                SizedBox(
-                  width: 300,
-                  height: 100,
-                  child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: [
-                        ElevatedButton(
-                          style: Theme.of(context)
-                              .elevatedButtonTheme
-                              .style!
-                              .copyWith(
-                                backgroundColor: MaterialStateProperty.all(
-                                  Theme.of(context).colorScheme.tertiary,
-                                ),
-                              ),
-                          onPressed: () {
-                            annotationNotifier.clearCurrentAnnotation();
-                            notifier.updateDetection(widget.detectionId);
-
-                            Future.delayed(const Duration(milliseconds: 100),
-                                () {
-                              annotationNotifier.reset();
-                            });
-                          },
-                          child: Text(
-                            "Done",
-                            style: textTheme.labelLarge!.copyWith(
-                              color: Theme.of(context).colorScheme.onTertiary,
-                            ),
-                          ),
-                        ),
-                      ],
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            ElevatedButton(
+              style: Theme.of(context).elevatedButtonTheme.style!.copyWith(
+                    backgroundColor: MaterialStateProperty.all(
+                      Theme.of(context).colorScheme.tertiary,
                     ),
                   ),
+              onPressed: () {
+                annotationNotifier.clearCurrentAnnotation();
+                notifier.updateDetection(widget.detectionId);
+
+                Future.delayed(const Duration(milliseconds: 100), () {
+                  annotationNotifier.reset();
+                });
+              },
+              child: Text(
+                "Done",
+                style: textTheme.labelLarge!.copyWith(
+                  color: Theme.of(context).colorScheme.onTertiary,
                 ),
-              ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -380,7 +357,7 @@ class _AnnotationPageState extends State<AnnotationPage> {
                   width: 300,
                   height: 300,
                   child: SingleChildScrollView(
-                    physics: NeverScrollableScrollPhysics(),
+                    physics: const NeverScrollableScrollPhysics(),
                     child: FreeDraw(
                       imageLink: snapshot.data as String,
                     ),

--- a/lib/pages/detection/annotation.dart
+++ b/lib/pages/detection/annotation.dart
@@ -1,5 +1,6 @@
 // Flutter imports:
 import 'dart:convert';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -121,8 +122,12 @@ class _AnnotationPageState extends State<AnnotationPage> {
                         },
                       );
                     }),
-                    Text("Don't show this screen again",
-                        style: Theme.of(context).textTheme.labelLarge),
+                    Expanded(
+                      child: Text(
+                        "Don't show this screen again",
+                        style: Theme.of(context).textTheme.labelLarge,
+                      ),
+                    ),
                   ],
                 ),
               ],

--- a/lib/pages/detection/annotation.dart
+++ b/lib/pages/detection/annotation.dart
@@ -211,6 +211,7 @@ class _AnnotationPageState extends State<AnnotationPage> {
 
                 Future.delayed(const Duration(milliseconds: 100), () {
                   annotationNotifier.reset();
+                  GoRouter.of(context).pop();
                 });
               },
               child: Text(


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Resolves various overflow issues on annotation page
  * Active label text no longer overflows, but fades out
  * Selection label buttons wrap rather than overflowing
  * How to annotate "dont show again" text doesn't overflow but wraps
* When swiping down/up on the annotation image, draws instead of scrolls
* When pressing "done", navigates back to the previous page

## Screenshots

![image](https://github.com/Soundbendor/smart-bin-app/assets/32113157/09777358-b55b-45fc-aaa3-06247d99a52d)
![image](https://github.com/Soundbendor/smart-bin-app/assets/32113157/463e24be-afc9-488e-9c33-d07a960112c9)
![image](https://github.com/Soundbendor/smart-bin-app/assets/32113157/d145184f-6883-40e8-84b2-5b9d9cfd6db8)
