### PR TITLE
Use shared API key

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,6 +61,12 @@ void main() async {
   await initPreferences();
   SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
 
+  try {
+    await dotenv.load(fileName: ".env");
+  } catch (e) {
+    debug("Error loading .env file");
+  }
+
   runApp(
     MultiProvider(
       providers: [
@@ -102,7 +108,10 @@ class _BinsightAiAppState extends State<BinsightAiApp>
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     Future<DateTime> timestamp = getLatestTimestamp();
-    fetchImageData('ae9e01c90bb6af06', timestamp);
+    fetchImageData(
+        sharedPreferences.getString(SharedPreferencesKeys.deviceApiID) ??
+            dotenv.env['DEVICE_ID']!,
+        timestamp);
   }
 
   @override
@@ -162,8 +171,9 @@ class _BinsightAiAppState extends State<BinsightAiApp>
     };
 
     final Uri uri = Uri.parse(url).replace(queryParameters: queryParams);
-    await dotenv.load(fileName: "assets/data/.env");
-    String apiKey = dotenv.env['API_KEY']!;
+    String apiKey = dotenv.env['API_KEY'] ??
+        sharedPreferences.getString(SharedPreferencesKeys.apiKey) ??
+        "";
     Map<String, String> headers = {
       'accept': 'application/json',
       'token': apiKey,
@@ -202,8 +212,9 @@ class _BinsightAiAppState extends State<BinsightAiApp>
   Future<void> retrieveImages(String deviceID, List<String> imageList) async {
     String url =
         'http://sb-binsight.dri.oregonstate.edu:30080/api/get_images?deviceID=$deviceID';
-    await dotenv.load(fileName: ".env");
-    String apiKey = dotenv.env['API_KEY']!;
+    String apiKey = dotenv.env['API_KEY'] ??
+        sharedPreferences.getString(SharedPreferencesKeys.apiKey) ??
+        "";
 
     var requestBody = imageList;
     debug("Image List $imageList");

--- a/test/widgets/main_test.dart
+++ b/test/widgets/main_test.dart
@@ -1,6 +1,7 @@
 // This file tests the entry point.
 
 // Flutter imports:
+import 'package:binsight_ai/util/shared_preferences.dart';
 import 'package:flutter/material.dart';
 
 // Package imports:
@@ -13,11 +14,100 @@ import 'package:binsight_ai/main.dart';
 import 'package:binsight_ai/util/routes.dart';
 import 'package:binsight_ai/util/providers/detection_notifier.dart';
 import 'package:binsight_ai/util/providers/setup_key_notifier.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../shared.dart';
+
+class FakeSharedPreferences implements SharedPreferences {
+  @override
+  String? getString(String key) {
+    return "";
+  }
+
+  @override
+  Future<bool> clear() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> commit() {
+    throw UnimplementedError();
+  }
+
+  @override
+  bool containsKey(String key) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Object? get(String key) {
+    throw UnimplementedError();
+  }
+
+  @override
+  bool? getBool(String key) {
+    throw UnimplementedError();
+  }
+
+  @override
+  double? getDouble(String key) {
+    throw UnimplementedError();
+  }
+
+  @override
+  int? getInt(String key) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Set<String> getKeys() {
+    throw UnimplementedError();
+  }
+
+  @override
+  List<String>? getStringList(String key) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> reload() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> remove(String key) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> setBool(String key, bool value) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> setDouble(String key, double value) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> setInt(String key, int value) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> setString(String key, String value) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> setStringList(String key, List<String> value) {
+    throw UnimplementedError();
+  }
+}
 
 /// Tests for main page
 void main() {
   testInit();
+  sharedPreferences = FakeSharedPreferences();
 
   testWidgets("Initial location is at set-up when devices don't exist",
       (widgetTester) async {


### PR DESCRIPTION
- If `.env` doesn't exist, use the shared preferences to retrieve the stored credentials