### PR TITLE
UI | Update detections to reflect annotated status

### DIFF
--- a/lib/pages/detection/detection.dart
+++ b/lib/pages/detection/detection.dart
@@ -1,4 +1,5 @@
 // Flutter imports:
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:binsight_ai/util/image.dart';
@@ -116,7 +117,7 @@ class _DetectionCardState extends State<_DetectionCard> {
                         onTap: onTap,
                         child: Container(
                           decoration: BoxDecoration(
-                            color: colorScheme.primary.withAlpha(200),
+                            color: ((jsonDecode(widget.detection.boxes ?? "[]") as List).isNotEmpty) ? colorScheme.tertiary : colorScheme.primary,
                             borderRadius: BorderRadius.circular(10),
                             boxShadow: const [
                               BoxShadow(
@@ -130,16 +131,16 @@ class _DetectionCardState extends State<_DetectionCard> {
                           child: Row(
                             children: [
                               Text(
-                                "Annotate",
+                                ((jsonDecode(widget.detection.boxes ?? "[]") as List).isNotEmpty) ? 
+                                "Annotated" : "Annotate",
                                 style: textTheme.labelMedium!
                                     .copyWith(color: Colors.white),
                               ),
                               IconButton(
-                                icon: const Icon(Icons.edit),
+                                icon: const Icon(Icons.edit, color: Colors.white),
                                 iconSize: 30,
                                 tooltip: "Annotate Image",
                                 onPressed: onTap,
-                                color: colorScheme.onPrimary,
                                 splashColor: colorScheme.onSecondary,
                               ),
                             ],

--- a/lib/pages/detection/detection.dart
+++ b/lib/pages/detection/detection.dart
@@ -117,7 +117,11 @@ class _DetectionCardState extends State<_DetectionCard> {
                         onTap: onTap,
                         child: Container(
                           decoration: BoxDecoration(
-                            color: ((jsonDecode(widget.detection.boxes ?? "[]") as List).isNotEmpty) ? colorScheme.tertiary : colorScheme.primary,
+                            color: ((jsonDecode(widget.detection.boxes ?? "[]")
+                                        as List)
+                                    .isNotEmpty)
+                                ? colorScheme.tertiary
+                                : colorScheme.primary,
                             borderRadius: BorderRadius.circular(10),
                             boxShadow: const [
                               BoxShadow(
@@ -131,13 +135,22 @@ class _DetectionCardState extends State<_DetectionCard> {
                           child: Row(
                             children: [
                               Text(
-                                ((jsonDecode(widget.detection.boxes ?? "[]") as List).isNotEmpty) ? 
-                                "Annotated" : "Annotate",
+                                ((jsonDecode(widget.detection.boxes ?? "[]")
+                                            as List)
+                                        .isNotEmpty)
+                                    ? "Annotated"
+                                    : "Annotate",
                                 style: textTheme.labelMedium!
                                     .copyWith(color: Colors.white),
                               ),
                               IconButton(
-                                icon: const Icon(Icons.edit, color: Colors.white),
+                                icon: Icon(
+                                    ((jsonDecode(widget.detection.boxes ?? "[]")
+                                                as List)
+                                            .isNotEmpty)
+                                        ? Icons.check_box
+                                        : Icons.edit,
+                                    color: Colors.white),
                                 iconSize: 30,
                                 tooltip: "Annotate Image",
                                 onPressed: onTap,

--- a/lib/widgets/detections.dart
+++ b/lib/widgets/detections.dart
@@ -73,6 +73,7 @@ class DetectionLargeListItem extends StatelessWidget {
                 Center(
                   child: Container(
                     width: 325,
+                    color: (jsonDecode(detection.boxes ?? "[]").isNotEmpty) ? mainColorScheme.tertiary : null,
                     margin: const EdgeInsets.only(bottom: 12, top: 12),
                     alignment: Alignment.center,
                     child: Stack(
@@ -153,6 +154,7 @@ class DetectionSmallListItem extends StatelessWidget {
         child: Card(
           color: colorScheme.onPrimary,
           child: ListTile(
+            tileColor: ((jsonDecode(detection.boxes ?? "[]") as List).isNotEmpty) ? mainColorScheme.tertiary : null,
             leading: Container(
               width: 50,
               height: 50,


### PR DESCRIPTION
## Description
* Updated detections list cards to be green when they have already been annotated
* Updated detections page "annotate" button to say "annotated" and turn green when it has been annotated

## Screenshots
![image](https://github.com/Soundbendor/smart-bin-app/assets/91357046/5d0974da-54a9-4d92-bb82-13d671b0033e)
![image](https://github.com/Soundbendor/smart-bin-app/assets/91357046/7f47c36c-b647-492a-b611-a7d7b681cfc1)
![image](https://github.com/Soundbendor/smart-bin-app/assets/91357046/63456a76-29c0-447c-98b0-6a8e96e4dce3)

